### PR TITLE
get initiative rolls working

### DIFF
--- a/cortexprime.js
+++ b/cortexprime.js
@@ -1,4 +1,5 @@
 import { CortexPrimeActor } from './module/entities/CortexPrimeActor.js'
+import { CortexPrimeCombatant } from './module/entities/CortexPrimeCombatant.js'
 import PlotPoint from './module/PlotPoint.js'
 import { preloadHandlebarsTemplates } from './module/handlebars/preloadTemplates.js'
 import { registerHandlebarHelpers } from './module/handlebars/helpers.js'
@@ -14,6 +15,7 @@ Hooks.once('init', () => {
   }
 
   CONFIG.Actor.documentClass = CortexPrimeActor
+  CONFIG.Combatant.documentClass = CortexPrimeCombatant
   CONFIG.Dice.terms['p'] = PlotPoint
 
   registerHandlebarHelpers()

--- a/lang/en.json
+++ b/lang/en.json
@@ -90,6 +90,8 @@
   "ImportExportSettings": "Import/Export Settings",
   "ImportExportSettingsHint": "Import or Export this game's settings.",
   "ImportVersionWarning": "The imported settings Cortex Prime version does not match the current Cortex Prime version being used.",
+  "InitiativeTraits": "Initiative Traits",
+  "InitiativeTraitsHint": "The Traits used to roll initiative, separated by commas and optional spaces",
   "Inputs": "Inputs",
   "Inset": "inset",
   "Italic": "italic",

--- a/module/actor/defaultInitiativeTraits.js
+++ b/module/actor/defaultInitiativeTraits.js
@@ -1,0 +1,1 @@
+export default 'Initiative'

--- a/module/entities/CortexPrimeActor.js
+++ b/module/entities/CortexPrimeActor.js
@@ -43,4 +43,33 @@ export class CortexPrimeActor extends Actor {
       'data.pp.value': value
     })
   }
+
+  getDiceObjectForTrait(trait) {
+    let diceObj = null
+    const myTraitSets = this.system.actorType.traitSets
+    for (const i in myTraitSets) {
+      let myTraits = myTraitSets[i].traits
+      for (const j in myTraits) {
+        let myTrait = myTraits[j]
+        let myName = myTrait.name
+        if(myName.toLowerCase() == trait.toLowerCase() ) {
+          diceObj = this._countDice(myTraits[j].dice.value)
+          return diceObj
+        }
+      }
+    }
+    return diceObj
+  }
+
+  _countDice(diceObj){
+    let diceCounter = {}
+    for (const [index, sides] of Object.entries(diceObj)) {
+      if (diceCounter.hasOwnProperty(sides)) {
+        diceCounter[sides] += 1
+      } else {
+        diceCounter[sides] = 1
+      }
+    }
+    return diceCounter
+  }
 }

--- a/module/entities/CortexPrimeCombatant.js
+++ b/module/entities/CortexPrimeCombatant.js
@@ -1,0 +1,38 @@
+import { localizer } from '../scripts/foundryHelpers.js'
+
+const SIDES_TO_ADDITION = {
+    4: 1,
+    6: 2,
+    8: 3,
+    10: 4,
+    12: 5
+}
+
+export class CortexPrimeCombatant extends Combatant {
+  getInitiativeRoll(formula) {
+    let traits = game.settings.get('cortexprime', 'initiativeTraits').split(',').map( s => s.trim() )
+      // get the actor
+      let formulae = []
+      let additive = 0
+      let actor = this.actor
+      // iterate over the traits
+      traits.forEach((trait) => {
+        let diceObj = actor.getDiceObjectForTrait(trait)
+          if (diceObj != null) {
+            let myFormula = ""
+            for (const [sides, dice] of Object.entries(diceObj)) {
+              additive += sides * dice
+              myFormula = `${dice}d${sides}`
+              formulae.push(myFormula)
+            }
+          }
+      })
+      // pull the trait values out of the actor and build the roll
+      let myRollFormula = formulae.join(' + ')
+      let myAdditivePercent = additive / 100.0
+      myRollFormula = `${myRollFormula} + ${myAdditivePercent}`
+      const myRoll = new Roll(myRollFormula)
+      return myRoll
+  }
+
+}

--- a/module/entities/CortexPrimeCombatant.js
+++ b/module/entities/CortexPrimeCombatant.js
@@ -28,9 +28,15 @@ export class CortexPrimeCombatant extends Combatant {
           }
       })
       // pull the trait values out of the actor and build the roll
-      let myRollFormula = formulae.join(' + ')
-      let myAdditivePercent = additive / 100.0
-      myRollFormula = `${myRollFormula} + ${myAdditivePercent}`
+      let myRollFormula = ''
+      if (formulae.length > 0) {
+        myRollFormula = formulae.join(' + ')
+        let myAdditivePercent = additive / 100.0
+        myRollFormula = `${myRollFormula} + ${myAdditivePercent}`
+      } else {
+	ui.notifications.warn("No rollable initiative traits found, using default.")
+	myRollFormula = "1d20" // default roll
+      }
       const myRoll = new Roll(myRollFormula)
       return myRoll
   }

--- a/module/settings/settings.js
+++ b/module/settings/settings.js
@@ -1,6 +1,7 @@
 import ActorSettings from './ActorSettings.js'
 import ImportExportSettings from './ImportExportSettings.js'
 import defaultActorTypes from '../actor/defaultActorTypes.js'
+import defaultInitiativeTraits from '../actor/defaultInitiativeTraits.js'
 import defaultThemes from '../theme/defaultThemes.js'
 import ThemeSettings from './ThemeSettings.js'
 
@@ -47,6 +48,16 @@ export const registerSettings = () => {
     label: localizer('RollResultSourceCollapsed'),
     default: false,
     type: Boolean,
+    config: true
+  })
+
+  game.settings.register('cortexprime', 'initiativeTraits', {
+    name: localizer('InitiativeTraits'),
+    hint: localizer('InitiativeTraitsHint'),
+    label: localizer('InitiativeTraits'),
+    default: defaultInitiativeTraits,
+    scope: 'world',
+    type: String,
     config: true
   })
 


### PR DESCRIPTION
This is my attempt to get initiative rolls working from the combat tracker. It looks for one or more rollable traits defined in the settings, and then searches through the character's trait sets for those, builds a roll formula and returns that as the combatant. If no traits are found it rolls a 1d20 by default.

Probably could use some caching/memoization for the trait lookup, since it could get expensive.  Just curious what you think of the approach, I know the JavaScript doesn't really match your style.